### PR TITLE
Hotkey enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *__pycache__*
 ntrrp_data/
 *.zip
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,19 @@
 {
-    "files.exclude": {
-        "**/__pycache__": true
-    },
-    "git.openRepositoryInParentFolders": "always",
-    "python.analysis.extraPaths": [
-        "C:\\Program Files\\QGIS 3.22.14\\apps\\Python39\\Lib\\site-packages",
-        "C:\\Program Files\\QGIS 3.22.14\\apps\\qgis-ltr\\python",
-        "C:\\Program Files\\QGIS 3.28.11\\apps\\Python39\\Lib\\site-packages",
-        "C:\\Program Files\\QGIS 3.28.11\\apps\\qgis-ltr\\python",
-        "/Applications/QGIS.app/Contents/Resources/python",
-        "/Applications/QGIS.app/Contents/Resources/python/site-packages",
-        "/Applications/QGIS-LTR.app/Contents/Resources/python",
-        "/Applications/QGIS-LTR.app/Contents/Resources/python/site-packages"
-    ],
-    "xml.validation.enabled": false,
-    "formatFiles.excludePattern": "**/resources_rc.py",
-    "mypy-type-checker.ignorePatterns": [
-        "nafi/**/*.py"
-    ],
+  "files.exclude": {
+    "**/__pycache__": true
+  },
+  "git.openRepositoryInParentFolders": "always",
+  "python.analysis.extraPaths": [
+    "C:\\Program Files\\QGIS 3.22.14\\apps\\Python39\\Lib\\site-packages",
+    "C:\\Program Files\\QGIS 3.22.14\\apps\\qgis-ltr\\python",
+    "C:\\Program Files\\QGIS 3.28.11\\apps\\Python39\\Lib\\site-packages",
+    "C:\\Program Files\\QGIS 3.28.11\\apps\\qgis-ltr\\python",
+    "/Applications/QGIS.app/Contents/Resources/python3.11",
+    "/Applications/QGIS.app/Contents/Resources/python3.11/site-packages",
+    "/Applications/QGIS-LTR.app/Contents/Resources/python",
+    "/Applications/QGIS-LTR.app/Contents/Resources/python/site-packages"
+  ],
+  "xml.validation.enabled": false,
+  "formatFiles.excludePattern": "**/resources_rc.py",
+  "mypy-type-checker.ignorePatterns": ["nafi/**/*.py"]
 }

--- a/naficp/metadata.txt
+++ b/naficp/metadata.txt
@@ -2,7 +2,7 @@
 name=Easy Copy and Paste
 qgisMinimumVersion=3.18.1
 description=Easily copy and paste features between QGIS layers
-version=1.0.1
+version=1.0.2
 author=Trailmarker
 email=tom@trailmarker.io
 about=This plug-in copies currently selected features in the map view to a target layer with a single click or Hotkey and commits them to the edit on that layer. 
@@ -18,7 +18,9 @@ icon=icon.png
 experimental=False
 deprecated=False
 category=Vector
-changelog=1.0.1
+changelog=1.0.2
+          - add configurable hotkeys for setting active layer to source or working layer
+          1.0.1
           - correct mypy errors and format all code
           1.0
           - bump plugin version for first release

--- a/naficp/naficp.json
+++ b/naficp/naficp.json
@@ -1,3 +1,5 @@
 {
-    "hotkey": "Ctrl+Z"
+  "pasteFeaturesHotKey": "Ctrl+Z",
+  "setActiveLayerAsSourceLayerHotKey": "Ctrl+X",
+  "setActiveLayerAsWorkingLayerHotKey": "Ctrl+C"
 }

--- a/naficp/naficp.json
+++ b/naficp/naficp.json
@@ -1,5 +1,5 @@
 {
   "pasteFeaturesHotKey": "Ctrl+Z",
-  "setActiveLayerAsSourceLayerHotKey": "Ctrl+X",
-  "setActiveLayerAsWorkingLayerHotKey": "Ctrl+C"
+  "setActiveLayerAsSourceLayerHotKey": "Shift+A",
+  "setActiveLayerAsWorkingLayerHotKey": "Shift+S"
 }

--- a/naficp/naficp.xml
+++ b/naficp/naficp.xml
@@ -1,0 +1,6 @@
+<!DOCTYPE shortcuts>
+<qgsshortcuts locale="en_AU" version="1.1">
+    <action setting="/shortcuts/Easy Cut and Paste Features" name="Paste Features" shortcut="Ctrl+Z"/>
+    <action setting="/shortcuts/Set Active Layer as Source Layer" name="Set Active Layer as Source Layer" shortcut="Shift+!"/>
+    <action setting="/shortcuts/Set Active Layer as Working Layer" name="Set Active Layer as Working Layer" shortcut="Shift+@"/>
+</qgsshortcuts>

--- a/naficp/src/naficp_dockwidget.py
+++ b/naficp/src/naficp_dockwidget.py
@@ -122,23 +122,19 @@ class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
     def setActiveLayerAsSourceLayer(self):
         """Set the currently active layer as the source layer."""
-        guiWarning("Setting active layer as source layer.")
-
-        # activeLayer = QgsInterface.activeLayer()
-        # if activeLayer is None:
-        #     guiWarning("No active layer to set as source layer.")
-        #     return
-        # self.sourceLayerComboBox.setCurrentLayer(activeLayer)
+        activeLayer = QgsInterface.activeLayer()
+        if activeLayer is None:
+            guiWarning("Set Active Layer As Source Layer: no layer added")
+        else:
+            self.sourceLayerComboBox.setLayer(activeLayer)
 
     def setActiveLayerAsWorkingLayer(self):
         """Set the currently active layer as the working layer."""
-        guiWarning("Setting active layer as working layer.")
-
-        # activeLayer = QgsInterface.activeLayer()
-        # if activeLayer is None:
-        #     guiWarning("No active layer to set as working layer.")
-        #     return
-        # self.workingLayerComboBox.setCurrentLayer(activeLayer)
+        activeLayer = QgsInterface.activeLayer()
+        if activeLayer is None:
+            guiWarning("Set Active Layer As Working Layer: no layer added")
+        else:
+            self.workingLayerComboBox.setLayer(activeLayer)
 
     def closeEvent(self, event):
         self.closingPlugin.emit()

--- a/naficp/src/naficp_dockwidget.py
+++ b/naficp/src/naficp_dockwidget.py
@@ -1,5 +1,5 @@
-from typing import Any
 import os
+from typing import Any
 
 from qgis.core import QgsMapLayerProxyModel
 from qgis.PyQt import QtWidgets, uic
@@ -8,7 +8,7 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction
 from qgis.utils import iface as QgsInterface
 
-from .utils import getConfiguredHotKey, guiError, NAFICP_NAME, guiWarning
+from .utils import guiError, guiWarning
 
 FORM_CLASS: Any
 FORM_CLASS, _ = uic.loadUiType(
@@ -21,18 +21,27 @@ FORM_CLASS, _ = uic.loadUiType(
 class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     closingPlugin = pyqtSignal()
 
-    def __init__(self, hotkey, pasteAction, parent=None):
+    def __init__(
+        self,
+        pasteFeaturesHotKey,
+        pasteFeaturesAction,
+        setActiveLayerAsSourceLayerAction,
+        setActiveLayerAsWorkingLayerAction,
+        parent=None,
+    ):
         super(NafiCpDockWidget, self).__init__(parent)
 
         self.setupUi(self)
 
-        self.hotkey = hotkey
-        self.pasteAction = pasteAction
+        self.pasteFeaturesHotKey = pasteFeaturesHotKey
+        self.pasteFeaturesAction = pasteFeaturesAction
+        self.setActiveLayerAsSourceLayerAction = setActiveLayerAsSourceLayerAction
+        self.setActiveLayerAsWorkingLayerAction = setActiveLayerAsWorkingLayerAction
 
-        # was having trouble getting this to lay out correctly, so have commented for now
+        # Was having trouble getting this to lay out correctly, so have commented for now
         # self.pasteFeaturesButton.setIcon(QIcon(":/plugins/naficp/images/paintbrush.png"))
         # self.pasteFeaturesButton.updateGeometry()
-        self.pasteFeaturesButton.setText(f"Paste Features ({self.hotkey})")
+        self.pasteFeaturesButton.setText(f"Paste Features ({self.pasteFeaturesHotKey})")
 
         self.sourceLayerComboBox.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.sourceLayerComboBox.setShowCrs(True)
@@ -40,13 +49,21 @@ class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.workingLayerComboBox.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.workingLayerComboBox.setShowCrs(True)
 
-        self.pasteAction.triggered.connect(self.copySelectedFeaturesFromSourceLayer)
-
+        self.pasteFeaturesAction.triggered.connect(
+            self.copySelectedFeaturesFromSourceLayer
+        )
         self.pasteFeaturesButton.clicked.connect(
             self.copySelectedFeaturesFromSourceLayer
         )
 
-    # miscellaneous sanity checks
+        self.setActiveLayerAsSourceLayerAction.triggered.connect(
+            self.setActiveLayerAsSourceLayer
+        )
+        self.setActiveLayerAsWorkingLayerAction.triggered.connect(
+            self.setActiveLayerAsWorkingLayer
+        )
+
+    # Miscellaneous sanity checks
     def checkLayersSelected(self, sourceLayer, workingLayer):
         if sourceLayer is None or workingLayer is None:
             guiError(
@@ -87,21 +104,41 @@ class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         QgsInterface.actionCopyFeatures().trigger()
         QgsInterface.setActiveLayer(workingLayer)
 
-        # if not currently editing, start editing this layer
+        # If not currently editing, start editing this layer
         wasEditing = workingLayer.isEditable()
         if not wasEditing:
             workingLayer.startEditing()
 
         QgsInterface.actionPasteFeatures().trigger()
 
-        # commit the changes, and stop editing if we weren't before
+        # Commit the changes, and stop editing if we weren't before
         workingLayer.commitChanges(stopEditing=(not wasEditing))
 
         QgsInterface.mainWindow().findChild(QAction, "mActionDeselectAll").trigger()
         QgsInterface.setActiveLayer(sourceLayer)
 
-        # repopulate the clipboard with no features to avoid re-pasting
+        # Repopulate the clipboard with no features to avoid re-pasting
         QgsInterface.actionCopyFeatures().trigger()
+
+    def setActiveLayerAsSourceLayer(self):
+        """Set the currently active layer as the source layer."""
+        guiWarning("Setting active layer as source layer.")
+
+        # activeLayer = QgsInterface.activeLayer()
+        # if activeLayer is None:
+        #     guiWarning("No active layer to set as source layer.")
+        #     return
+        # self.sourceLayerComboBox.setCurrentLayer(activeLayer)
+
+    def setActiveLayerAsWorkingLayer(self):
+        """Set the currently active layer as the working layer."""
+        guiWarning("Setting active layer as working layer.")
+
+        # activeLayer = QgsInterface.activeLayer()
+        # if activeLayer is None:
+        #     guiWarning("No active layer to set as working layer.")
+        #     return
+        # self.workingLayerComboBox.setCurrentLayer(activeLayer)
 
     def closeEvent(self, event):
         self.closingPlugin.emit()

--- a/naficp/src/utils.py
+++ b/naficp/src/utils.py
@@ -6,7 +6,9 @@ from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtWidgets import QMessageBox
 
 NAFICP_NAME = "Easy Copy and Paste"
-NAFICP_DEFAULT_HOTKEY = "Ctrl+Z"
+NAFICP_DEFAULT_PASTE_FEATURES_HOTKEY = "Ctrl+Z"
+NAFICP_DEFAULT_SET_ACTIVE_LAYER_AS_SOURCE_LAYER_HOTKEY = "Ctrl+Shift+S"
+NAFICP_DEFAULT_SET_ACTIVE_LAYER_AS_WORKING_LAYER_HOTKEY = "Ctrl+Shift+D"
 NAFICP_CONFIG_FILENAME = "naficp.json"
 
 
@@ -50,6 +52,22 @@ def getSetting(setting, default=None):
         return default
 
 
-def getConfiguredHotKey():
-    """Get the configured hot key."""
-    return getSetting("hotkey", NAFICP_DEFAULT_HOTKEY)
+def getConfiguredPasteFeaturesHotKey():
+    """Get the configured 'Paste Features' hot key."""
+    return getSetting("hotkey", NAFICP_DEFAULT_PASTE_FEATURES_HOTKEY)
+
+
+def getConfiguredSetActiveLayerAsSourceLayerHotKey():
+    """Get the configured 'Set Active Layer as Source Layer' hot key."""
+    return getSetting(
+        "setActiveLayerAsSourceLayerHotKey",
+        NAFICP_DEFAULT_SET_ACTIVE_LAYER_AS_SOURCE_LAYER_HOTKEY,
+    )
+
+
+def getConfiguredSetActiveLayerAsWorkingLayerHotKey():
+    """Get the configured 'Set Active Layer as Working Layer' hot key."""
+    return getSetting(
+        "setActiveLayerAsWorkingLayerHotKey",
+        NAFICP_DEFAULT_SET_ACTIVE_LAYER_AS_WORKING_LAYER_HOTKEY,
+    )

--- a/ntrrp/ntrrp.json
+++ b/ntrrp/ntrrp.json
@@ -1,11 +1,9 @@
 {
-    "NTRRP_REGIONS": [
-        "Darwin",
-        "Katherine"
-    ],
-    "NTRRP_WMS_URL": "https://firenorth.org.au/hires/mapserver/bfnt/gwc/service/wms",
-    "NTRRP_WMTS_URL": "https://firenorth.org.au/hires/mapserver/bfnt/gwc/service/wmts",
-    "NTRRP_DATA_URL": "https://firenorth.org.au/hires/bfnt/downloads",
-    "NTRRP_UPLOAD_URL": "https://firenorth.org.au/hires/bfnt/upload.php",
-    "NTRRP_API_URL": "https://firenorth.org.au/hires/bfnt/api/"
+  "NTRRP_REGIONS": ["Darwin", "Katherine"],
+  "NTRRP_WMS_URL": "https://firenorth.org.au/hires/mapserver/bfnt/gwc/service/wms",
+  "NTRRP_WMTS_URL": "https://firenorth.org.au/hires/mapserver/bfnt/gwc/service/wmts",
+  "NTRRP_DATA_URL": "https://firenorth.org.au/hires/bfnt/downloads",
+  "NTRRP_UPLOAD_URL": "https://firenorth.org.au/hires/bfnt/upload.php",
+  "NTRRP_API_URL": "https://firenorth.org.au/hires/bfnt/api/",
+  "NTRRP_DO_FULL_SEGMENTATION_DOWNLOAD": true
 }

--- a/ntrrp/src/services/mapping_service.py
+++ b/ntrrp/src/services/mapping_service.py
@@ -18,6 +18,7 @@ from ntrrp.src.models import (
 )
 from ntrrp.src.utils import (
     NTRRP_REGIONS,
+    doFullSegmentationDownload,
     deriveWorkingDirectory,
     ensureDirectory,
     qgsDebug,
@@ -64,20 +65,28 @@ class MappingService(QObject):
 
     def downloadSegmentationData(self, mapping: Mapping):
         """Download segmentation features from NAFI and call back to add them to the map."""
-        # if deriveWorkingDirectory() is None:
-        #     return None
+        if doFullSegmentationDownload():
+            if deriveWorkingDirectory() is None:
+                return None
 
-        # params = {
-        #     'Region': NTRRP_REGIONS.index(self.region)
-        # }
-        # dialog = processing.createAlgorithmDialog(
-        #     'BurntAreas:DownloadSegmentationData', params)
-        # dialog.algorithmFinished.connect(lambda _: self.addSegmentationLayers(mapping,
-        #     dialog.results()['SegmentationDataDirectory']))
-        # for signal in [dialog.algorithmFinished, dialog.accepted, dialog.rejected, dialog.destroyed]:
-        #     signal.connect(lambda: self.dataDownloadFinished.emit())
-        # dialog.show()
-        # dialog.runButton().click()
+            params = {"Region": NTRRP_REGIONS.index(self.region)}
+            dialog = processing.createAlgorithmDialog(
+                "BurntAreas:DownloadSegmentationData", params
+            )
+            dialog.algorithmFinished.connect(
+                lambda _: self.addSegmentationLayers(
+                    mapping, dialog.results()["SegmentationDataDirectory"]
+                )
+            )
+            for signal in [
+                dialog.algorithmFinished,
+                dialog.accepted,
+                dialog.rejected,
+                dialog.destroyed,
+            ]:
+                signal.connect(lambda: self.dataDownloadFinished.emit())
+            dialog.show()
+            dialog.runButton().click()
 
         self.addMappingLayers(mapping)
 

--- a/ntrrp/src/utils.py
+++ b/ntrrp/src/utils.py
@@ -62,6 +62,11 @@ def deriveWorkingDirectory():
     return path.dirname(projectFilePath)
 
 
+def doFullSegmentationDownload() -> bool:
+    """Return whether to download the full segmentation."""
+    return bool(getSetting("NTRRP_DO_FULL_SEGMENTATION_DOWNLOAD", False))
+
+
 def getSetting(setting, default=None):
     """Retrieve an NTRRP setting."""
     try:


### PR DESCRIPTION
1. Add a menu item "Set Active Layer as Working Layer" that sets the active layer to the C&P working layer
2. Add a menu item "Set Active Layer as Source Layer" that sets the active layer to the C&P source layer
3. Add two new hotkeys configurable in naficp.json that activate these menu items
4. Report a friendly error if there is no active layer when the menu items are activated

Two new hotkeys added with default hotkey configurations:

"Set Active Layer as Source Layer": Shift+A 
"Set Active Layer as Source Layer": Shift+B 