### PR TITLE
naficp: responsive layout and hotkey labels

### DIFF
--- a/naficp/metadata.txt
+++ b/naficp/metadata.txt
@@ -2,7 +2,7 @@
 name=Easy Copy and Paste
 qgisMinimumVersion=3.18.1
 description=Easily copy and paste features between QGIS layers
-version=1.0.2
+version=1.0.3
 author=Trailmarker
 email=tom@trailmarker.io
 about=This plug-in copies currently selected features in the map view to a target layer with a single click or Hotkey and commits them to the edit on that layer. 
@@ -18,7 +18,10 @@ icon=icon.png
 experimental=False
 deprecated=False
 category=Vector
-changelog=1.0.2
+changelog=1.0.3
+          - responsively stack source and working layer labels above their dropdowns when the dock widget is narrow
+          - display the configured hotkeys alongside the source and working layer labels
+          1.0.2
           - add configurable hotkeys for setting active layer to source or working layer
           1.0.1
           - correct mypy errors and format all code

--- a/naficp/naficp.py
+++ b/naficp/naficp.py
@@ -259,7 +259,9 @@ class NafiCp:
                 self.dockwidget = NafiCpDockWidget(
                     self.pasteFeaturesHotKey,
                     self.pasteFeaturesAction,
+                    self.setActiveLayerAsSourceLayerHotKey,
                     self.setActiveLayerAsSourceLayerAction,
+                    self.setActiveLayerAsWorkingLayerHotKey,
                     self.setActiveLayerAsWorkingLayerAction,
                 )
 

--- a/naficp/src/naficp_dockwidget.py
+++ b/naficp/src/naficp_dockwidget.py
@@ -25,7 +25,9 @@ class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self,
         pasteFeaturesHotKey,
         pasteFeaturesAction,
+        setActiveLayerAsSourceLayerHotKey,
         setActiveLayerAsSourceLayerAction,
+        setActiveLayerAsWorkingLayerHotKey,
         setActiveLayerAsWorkingLayerAction,
         parent=None,
     ):
@@ -35,13 +37,21 @@ class NafiCpDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         self.pasteFeaturesHotKey = pasteFeaturesHotKey
         self.pasteFeaturesAction = pasteFeaturesAction
+        self.setActiveLayerAsSourceLayerHotKey = setActiveLayerAsSourceLayerHotKey
         self.setActiveLayerAsSourceLayerAction = setActiveLayerAsSourceLayerAction
+        self.setActiveLayerAsWorkingLayerHotKey = setActiveLayerAsWorkingLayerHotKey
         self.setActiveLayerAsWorkingLayerAction = setActiveLayerAsWorkingLayerAction
 
         # Was having trouble getting this to lay out correctly, so have commented for now
         # self.pasteFeaturesButton.setIcon(QIcon(":/plugins/naficp/images/paintbrush.png"))
         # self.pasteFeaturesButton.updateGeometry()
         self.pasteFeaturesButton.setText(f"Paste Features ({self.pasteFeaturesHotKey})")
+        self.sourceLayerLabel.setText(
+            f"Select source layer ({self.setActiveLayerAsSourceLayerHotKey})"
+        )
+        self.workingLayerLabel.setText(
+            f"Select working layer ({self.setActiveLayerAsWorkingLayerHotKey})"
+        )
 
         self.sourceLayerComboBox.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.sourceLayerComboBox.setShowCrs(True)

--- a/naficp/ui/naficp_dockwidget_base.ui
+++ b/naficp/ui/naficp_dockwidget_base.ui
@@ -88,12 +88,6 @@
                         </property>
                         <item row="0" column="0">
                             <widget class="QLabel" name="sourceLayerLabel">
-                                <property name="font">
-                                    <font>
-                                        <weight>75</weight>
-                                        <bold>true</bold>
-                                    </font>
-                                </property>
                                 <property name="text">
                                     <string>Select source layer</string>
                                 </property>
@@ -123,12 +117,6 @@
                         </item>
                         <item row="1" column="0">
                             <widget class="QLabel" name="workingLayerLabel">
-                                <property name="font">
-                                    <font>
-                                        <weight>75</weight>
-                                        <bold>true</bold>
-                                    </font>
-                                </property>
                                 <property name="text">
                                     <string>Select working layer</string>
                                 </property>

--- a/naficp/ui/naficp_dockwidget_base.ui
+++ b/naficp/ui/naficp_dockwidget_base.ui
@@ -18,7 +18,7 @@
         </property>
         <property name="minimumSize">
             <size>
-                <width>416</width>
+                <width>180</width>
                 <height>148</height>
             </size>
         </property>
@@ -79,151 +79,82 @@
                     </layout>
                 </item>
                 <item row="0" column="0">
-                    <layout class="QHBoxLayout" name="layersLayout">
-                        <item>
-                            <layout class="QVBoxLayout" name="labelsLayout">
-                                <property name="sizeConstraint">
-                                    <enum>QLayout::SetMinimumSize</enum>
+                    <layout class="QFormLayout" name="layersLayout">
+                        <property name="rowWrapPolicy">
+                            <enum>QFormLayout::WrapLongRows</enum>
+                        </property>
+                        <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                        <item row="0" column="0">
+                            <widget class="QLabel" name="sourceLayerLabel">
+                                <property name="font">
+                                    <font>
+                                        <weight>75</weight>
+                                        <bold>true</bold>
+                                    </font>
                                 </property>
-                                <item>
-                                    <layout class="QHBoxLayout" name="sourceLayerLayout">
-                                        <item>
-                                            <spacer name="sourceLayerSpacer">
-                                                <property name="orientation">
-                                                    <enum>Qt::Horizontal</enum>
-                                                </property>
-                                                <property name="sizeType">
-                                                    <enum>QSizePolicy::Minimum</enum>
-                                                </property>
-                                                <property name="sizeHint" stdset="0">
-                                                    <size>
-                                                        <width>40</width>
-                                                        <height>20</height>
-                                                    </size>
-                                                </property>
-                                            </spacer>
-                                        </item>
-                                        <item>
-                                            <widget class="QLabel" name="sourceLayerLabel">
-                                                <property name="sizePolicy">
-                                                    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                                        <horstretch>0</horstretch>
-                                                        <verstretch>0</verstretch>
-                                                    </sizepolicy>
-                                                </property>
-                                                <property name="maximumSize">
-                                                    <size>
-                                                        <width>150</width>
-                                                        <height>16777215</height>
-                                                    </size>
-                                                </property>
-                                                <property name="font">
-                                                    <font>
-                                                        <weight>75</weight>
-                                                        <bold>true</bold>
-                                                    </font>
-                                                </property>
-                                                <property name="text">
-                                                    <string>Select source layer</string>
-                                                </property>
-                                            </widget>
-                                        </item>
-                                    </layout>
-                                </item>
-                                <item>
-                                    <layout class="QHBoxLayout" name="workingLayerLayout">
-                                        <item>
-                                            <spacer name="workingLayerSpacer">
-                                                <property name="orientation">
-                                                    <enum>Qt::Horizontal</enum>
-                                                </property>
-                                                <property name="sizeType">
-                                                    <enum>QSizePolicy::Minimum</enum>
-                                                </property>
-                                                <property name="sizeHint" stdset="0">
-                                                    <size>
-                                                        <width>40</width>
-                                                        <height>20</height>
-                                                    </size>
-                                                </property>
-                                            </spacer>
-                                        </item>
-                                        <item>
-                                            <widget class="QLabel" name="workingLayerLabel">
-                                                <property name="sizePolicy">
-                                                    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                                        <horstretch>0</horstretch>
-                                                        <verstretch>0</verstretch>
-                                                    </sizepolicy>
-                                                </property>
-                                                <property name="maximumSize">
-                                                    <size>
-                                                        <width>150</width>
-                                                        <height>16777215</height>
-                                                    </size>
-                                                </property>
-                                                <property name="font">
-                                                    <font>
-                                                        <weight>75</weight>
-                                                        <bold>true</bold>
-                                                    </font>
-                                                </property>
-                                                <property name="text">
-                                                    <string>Select working layer</string>
-                                                </property>
-                                            </widget>
-                                        </item>
-                                    </layout>
-                                </item>
-                            </layout>
+                                <property name="text">
+                                    <string>Select source layer</string>
+                                </property>
+                            </widget>
                         </item>
-                        <item>
-                            <layout class="QVBoxLayout" name="mapLayerComboBoxLayout">
-                                <item>
-                                    <widget class="QgsMapLayerComboBox" name="sourceLayerComboBox">
-                                        <property name="sizePolicy">
-                                            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                                                <horstretch>0</horstretch>
-                                                <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                        </property>
-                                        <property name="minimumSize">
-                                            <size>
-                                                <width>200</width>
-                                                <height>0</height>
-                                            </size>
-                                        </property>
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>400</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                    </widget>
-                                </item>
-                                <item>
-                                    <widget class="QgsMapLayerComboBox" name="workingLayerComboBox">
-                                        <property name="sizePolicy">
-                                            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                                                <horstretch>0</horstretch>
-                                                <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                        </property>
-                                        <property name="minimumSize">
-                                            <size>
-                                                <width>200</width>
-                                                <height>0</height>
-                                            </size>
-                                        </property>
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>400</width>
-                                                <height>16777215</height>
-                                            </size>
-                                        </property>
-                                    </widget>
-                                </item>
-                            </layout>
+                        <item row="0" column="1">
+                            <widget class="QgsMapLayerComboBox" name="sourceLayerComboBox">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                    <size>
+                                        <width>80</width>
+                                        <height>0</height>
+                                    </size>
+                                </property>
+                                <property name="maximumSize">
+                                    <size>
+                                        <width>400</width>
+                                        <height>16777215</height>
+                                    </size>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="0">
+                            <widget class="QLabel" name="workingLayerLabel">
+                                <property name="font">
+                                    <font>
+                                        <weight>75</weight>
+                                        <bold>true</bold>
+                                    </font>
+                                </property>
+                                <property name="text">
+                                    <string>Select working layer</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="1">
+                            <widget class="QgsMapLayerComboBox" name="workingLayerComboBox">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                    <size>
+                                        <width>80</width>
+                                        <height>0</height>
+                                    </size>
+                                </property>
+                                <property name="maximumSize">
+                                    <size>
+                                        <width>400</width>
+                                        <height>16777215</height>
+                                    </size>
+                                </property>
+                            </widget>
                         </item>
                     </layout>
                 </item>


### PR DESCRIPTION
- labels stack above the dropdowns when the dock gets narrow (QFormLayout wrap)
- labels now show the configured hotkeys, e.g. `Select source layer (Ctrl+Shift+S)`
- bump to 1.0.3