### PR TITLE
include LICENSE in plugin release archives

### DIFF
--- a/plugins/naficp/metadata.txt
+++ b/plugins/naficp/metadata.txt
@@ -2,7 +2,7 @@
 name=Easy Copy and Paste
 qgisMinimumVersion=3.18.1
 description=Easily copy and paste features between QGIS layers
-version=1.0.5
+version=1.0.6
 author=Trailmarker
 email=tom@trailmarker.io
 about=This plug-in copies currently selected features in the map view to a target layer with a single click or Hotkey and commits them to the edit on that layer. 
@@ -18,7 +18,9 @@ icon=icon.png
 experimental=False
 deprecated=False
 category=Vector
-changelog=1.0.5
+changelog=1.0.6
+          - include LICENSE in the release archive
+          1.0.5
           - fix hotkey labels to refresh when naficp.json is edited mid-session
           1.0.4
           - fix hotkey labels to display actual configured shortcuts

--- a/release_plugin.sh
+++ b/release_plugin.sh
@@ -29,6 +29,8 @@ cd deployment/plugins || exit
 cp "${plugin_name}/images/icon.png" "${plugin_name}/icon.png"
 # rm -rf "${plugin_name}/images"
 
+# include the repository LICENSE alongside the plugin
+cp "../LICENSE" "${plugin_name}/LICENSE"
 
 # zip up the ${plugin_name} directory only into a versioned archive
 zip -rq "${archiveName}" "${plugin_name}"


### PR DESCRIPTION
- copy repository LICENSE into the plugin directory before zipping
- bump to 1.0.6