### PR TITLE
clean up flake8 warnings in nafi plugin

### DIFF
--- a/plugins/nafi/metadata.txt
+++ b/plugins/nafi/metadata.txt
@@ -2,7 +2,7 @@
 name=NAFI Fire Maps
 qgisMinimumVersion=3.8.1
 description=North Australia & Rangelands Fire Information (NAFI) Map Services
-version=1.0.5
+version=1.0.6
 author=Tom Lynch
 email=tom@trailmarker.io
 about=Directory of NAFI web services which provide accurate 250m scale fire scar (burnt area) mapping across most of the Australian rangelands. The service provides annual and multi-year fire histories from 2000 to the present. The data are validated in the northern rangelands. A cleaned up hotspot dataset for the rangelands back to 2000 is also provided.
@@ -16,7 +16,9 @@ experimental=False
 deprecated=False
 category=Web
 server=False
-changelog=1.0.5
+changelog=1.0.6
+          - clean up flake8 warnings flagged by QGIS plugins repo
+          1.0.5
           - correct mypy errors and format all code
           1.0.4
           - alter image format specification to get Geoscience Australia topographic basemap working again

--- a/plugins/nafi/nafi.py
+++ b/plugins/nafi/nafi.py
@@ -213,7 +213,7 @@ class Nafi:
             # dockwidget may not exist if:
             #    first run of plugin
             #    removed on close (see self.onClosePlugin method)
-            if self.dockwidget == None:
+            if self.dockwidget is None:
                 # Create the dockwidget (after translation) and keep reference
                 self.dockwidget = NafiDockWidget()
 

--- a/plugins/nafi/src/google_xyz_item.py
+++ b/plugins/nafi/src/google_xyz_item.py
@@ -36,7 +36,7 @@ class GoogleXyzItem(QStandardItem):
             QgsProject.instance().addMapLayer(tmsLayer)
         else:
             error = (
-                f"An error occurred adding the layer title to the map.\n"
-                f"Check your QGIS logs for details."
+                "An error occurred adding the layer title to the map.\n"
+                "Check your QGIS logs for details."
             )
             guiError(error)

--- a/plugins/nafi/src/ibra_wms_item.py
+++ b/plugins/nafi/src/ibra_wms_item.py
@@ -2,7 +2,6 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon, QStandardItem
 
 from owslib.wms import WebMapService
-from owslib.map.wms111 import ContentMetadata, WebMapService_1_1_1
 
 from qgis.core import QgsProject, QgsRasterLayer
 
@@ -37,6 +36,6 @@ class IbraWmsItem(QStandardItem):
         else:
             error = (
                 f"An error occurred adding the layer {self.owsLayer.title} to the map.\n"
-                f"Check your QGIS logs for details."
+                "Check your QGIS logs for details."
             )
             guiError(error)

--- a/plugins/nafi/src/nafi_about_dialog.py
+++ b/plugins/nafi/src/nafi_about_dialog.py
@@ -1,5 +1,4 @@
-from qgis.PyQt import QtGui, QtWidgets, uic
-from qgis.PyQt.QtWidgets import QLayout
+from qgis.PyQt import QtWidgets
 
 from .nafi_about_dialog_base import Ui_NafiAboutDialogBase
 

--- a/plugins/nafi/src/nafi_capabilities_reader.py
+++ b/plugins/nafi/src/nafi_capabilities_reader.py
@@ -3,7 +3,7 @@ from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest, QSslSocket
 
 from qgis.core import QgsBlockingNetworkRequest
 
-from .utils import connectionError, guiError, qgsDebug
+from .utils import connectionError
 
 
 class NafiCapabilitiesReader(QObject):

--- a/plugins/nafi/src/nafi_dockwidget.py
+++ b/plugins/nafi/src/nafi_dockwidget.py
@@ -21,11 +21,9 @@
  ***************************************************************************/
 """
 
-import os
 import webbrowser
-from urllib import parse
 
-from qgis.PyQt import QtGui, QtWidgets, uic
+from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtCore import (
     pyqtSignal,
     QRegExp,
@@ -34,10 +32,6 @@ from qgis.PyQt.QtCore import (
     Qt,
     QModelIndex,
 )
-from qgis.PyQt.QtGui import QFont, QIcon, QPixmap, QStandardItem, QStandardItemModel
-from qgis.PyQt.QtWidgets import QApplication
-
-from qgis.core import Qgis, QgsRasterLayer, QgsProject
 
 from .google_xyz_item import GoogleXyzItem
 from .ibra_wms_item import IbraWmsItem
@@ -47,7 +41,7 @@ from .nafi_about_dialog import NafiAboutDialog
 from .nafi_capabilities_reader import NafiCapabilitiesReader
 from .nafi_dockwidget_base import Ui_NafiDockWidgetBase
 from .nafi_tree_view_model import NafiTreeViewModel
-from .utils import getNafiDataUrl, getNafiUrl, qgsDebug
+from .utils import getNafiDataUrl, getNafiUrl
 from .wms_item import WmsItem
 
 

--- a/plugins/nafi/src/nafi_tree_view_model.py
+++ b/plugins/nafi/src/nafi_tree_view_model.py
@@ -7,7 +7,7 @@ from qgis.PyQt.QtGui import QIcon, QStandardItem, QStandardItemModel
 from owslib.etree import etree
 from owslib.map.wms111 import ContentMetadata
 
-from .utils import capabilitiesError, qgsDebug
+from .utils import capabilitiesError
 from .wms_item import WmsItem
 
 UNWANTED_LAYERS = ["NODATA_RASTER"]
@@ -46,7 +46,8 @@ class NafiTreeViewModel(QStandardItemModel):
             # recursively gather content metadata for all layer elements, this is stolen
             # from OWSLib because it won't let us configure the parser the way we need to
             # to avoid unwanted network activity, entity resolutions etc
-            # see https://github.com/geopython/OWSLib/blob/8a94500c2137082dfc4e59acd15389312bcb63fb/owslib/map/wms111.py#L113
+            # see https://github.com/geopython/OWSLib/blob/8a94500c2137082dfc4e59acd15389312bcb63fb
+            # /owslib/map/wms111.py#L113
 
             # TODO merge this gather with the other tree manipulation functions below
 
@@ -101,8 +102,8 @@ class NafiTreeViewModel(QStandardItemModel):
 
     @staticmethod
     def addOwsLayerToTreeViewModel(model, wmsUrl, owsLayer, unwantedLayers=[]):
-        """Add an OWSLib layer to a QStandardItemModel based structure, potentially with descendant layers and
-        using a list of 'blacklisted' layer names."""
+        """Add an OWSLib layer to a QStandardItemModel based structure, potentially with descendant layers
+        and using a list of 'blacklisted' layer names."""
         assert isinstance(model, QStandardItem) or isinstance(model, QStandardItemModel)
         assert isinstance(owsLayer, ContentMetadata)
 
@@ -137,7 +138,7 @@ class NafiTreeViewModel(QStandardItemModel):
                 parents[layer.title] = layer
 
         # if all parents are root layers, return
-        if all(map(lambda l: l.parent is None, parents.values())):
+        if all(map(lambda layer: layer.parent is None, parents.values())):
             return list(parents.values())
         # otherwise recurse
         else:

--- a/plugins/nafi/src/oz_topo_wmts_item.py
+++ b/plugins/nafi/src/oz_topo_wmts_item.py
@@ -4,7 +4,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon, QStandardItem
 from qgis.core import QgsProject, QgsRasterLayer
 
-from .utils import getOzTopoParams, guiError, qgsDebug
+from .utils import getOzTopoParams, guiError
 
 WMTS_LABEL = "Australian Topographic Base Map"
 
@@ -29,6 +29,6 @@ class OzTopoWmtsItem(QStandardItem):
         else:
             error = (
                 f"An error occurred adding the layer {WMTS_LABEL} to the map.\n"
-                f"Check your QGIS logs for details."
+                "Check your QGIS logs for details."
             )
             guiError(error)

--- a/plugins/nafi/src/utils.py
+++ b/plugins/nafi/src/utils.py
@@ -6,7 +6,10 @@ from qgis.core import Qgis, QgsMessageLog, QgsCoordinateReferenceSystem
 IBRA_URL = "http://www.environment.gov.au/mapping/services/ogc_services/IBRA7_Subregions/MapServer/WMSServer"
 NAFI_DATA_URL = "https://firenorth.org.au/nafi3/views/data/Download.html"
 NAFI_URL = "https://www.firenorth.org.au/public"
-OZ_TOPO_URL = "https://services.ga.gov.au/gis/rest/services/Topographic_Base_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+OZ_TOPO_URL = (
+    "https://services.ga.gov.au/gis/rest/services/Topographic_Base_Map"
+    "/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+)
 
 
 def qgsDebug(message, level=Qgis.Info):
@@ -75,8 +78,8 @@ def setDefaultProjectCrs(project):
 def connectionError(logMessage):
     """Raise a connection error."""
     error = (
-        f"Error connecting to NAFI services!\n"
-        f"Check the QGIS NAFI Fire Maps message log for details."
+        "Error connecting to NAFI services!\n"
+        "Check the QGIS NAFI Fire Maps message log for details."
     )
     guiError(error)
     qgsDebug(logMessage, Qgis.Critical)
@@ -85,8 +88,8 @@ def connectionError(logMessage):
 def capabilitiesError(errorString, capsXml):
     """Raise an error parsing the WMS capabilities file."""
     error = (
-        f"Error parsing the retrieved NAFI WMS capabilities!\n"
-        f"Check the QGIS NAFI Fire Maps message log for details."
+        "Error parsing the retrieved NAFI WMS capabilities!\n"
+        "Check the QGIS NAFI Fire Maps message log for details."
     )
     guiError(error)
     logMessage = f"NAFI WMS capabilities XML parse failure: {errorString}"

--- a/plugins/nafi/src/wms_item.py
+++ b/plugins/nafi/src/wms_item.py
@@ -1,10 +1,10 @@
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon, QStandardItem
-from owslib.map.wms111 import ContentMetadata, WebMapService_1_1_1
+from owslib.map.wms111 import ContentMetadata
 
-from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsRasterLayer
+from qgis.core import QgsProject, QgsRasterLayer
 
-from .utils import guiError, guiWarning, setDefaultProjectCrs
+from .utils import guiError, setDefaultProjectCrs
 
 
 class WmsItem(QStandardItem):
@@ -76,6 +76,6 @@ class WmsItem(QStandardItem):
             else:
                 error = (
                     f"An error occurred adding the layer {self.owsLayer.title} to the map.\n"
-                    f"Check your QGIS logs for details."
+                    "Check your QGIS logs for details."
                 )
                 guiError(error)


### PR DESCRIPTION
- remove unused imports across nafi/src/ modules
- replace `dockwidget == None` with `is None`
- drop redundant f-string prefixes on literal-only strings
- rename ambiguous `l` lambda param in tree view model
- wrap over-length URL constant in utils
- bump version to 1.0.6