### PR TITLE
clean up flake8 warnings and fix headless load in ntrrp plugin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,9 @@
 # (pyflakes + pycodestyle E/W). Line length bumped to 120 to align with the
 # repo's ruff config in pyproject.toml.
 max-line-length = 120
+# W503 (line break before binary operator) is the modern PEP 8 preference;
+# the companion W504 (break after) covers the same formatting choice.
+extend-ignore = W503
 extend-exclude =
     */resources_rc.py,
     __pycache__,

--- a/plugins/ntrrp/metadata.txt
+++ b/plugins/ntrrp/metadata.txt
@@ -2,7 +2,7 @@
 name=NAFI Burnt Areas Mapping
 qgisMinimumVersion=3.18.1
 description=NAFI Burnt Areas Mapping Tools
-version=1.2.0
+version=1.2.1
 author=Tom Lynch
 email=tom@trailmarker.io
 about=This plugin is part of a project to provide high resolution burnt area mapping in northern Australia through the active fire season.
@@ -17,7 +17,10 @@ experimental=False
 deprecated=False
 category=Web
 server=False
-changelog=1.2.0
+changelog=1.2.1
+          - clean up flake8 warnings flagged by QGIS plugins repo
+          - guard module-level 'import processing' so the plugin loads in headless QGIS
+          1.2.0
           - major UI update
           - removed user handling of 'working layers'
           - reload mapping activity from filesystem

--- a/plugins/ntrrp/src/content_metadata_utils.py
+++ b/plugins/ntrrp/src/content_metadata_utils.py
@@ -7,7 +7,10 @@ from owslib.map.wms111 import ContentMetadata
 
 
 def parseContentMetadataRegion(metadata: ContentMetadata) -> Optional[str]:
-    """Parse the region from a Hires WMS or WMTS layer title. The expected format is T1T2 Difference Image [Darwin_T20210628_dMIRBI_T20210623]."""
+    """Parse the region from a Hires WMS or WMTS layer title.
+
+    The expected format is T1T2 Difference Image [Darwin_T20210628_dMIRBI_T20210623].
+    """
     match = re.match("^.*\\[(.*)\\].*$", metadata.title)
     if match is not None:
         ntrrpMeta = match.group(1)
@@ -18,7 +21,10 @@ def parseContentMetadataRegion(metadata: ContentMetadata) -> Optional[str]:
 
 
 def parseContentMetadataDescription(metadata: ContentMetadata) -> str:
-    """Parse the description from a Hires WMS or WMTS layer title. The expected format is T1T2 Difference Image [Darwin_T20210628_dMIRBI_T20210623]."""
+    """Parse the description from a Hires WMS or WMTS layer title.
+
+    The expected format is T1T2 Difference Image [Darwin_T20210628_dMIRBI_T20210623].
+    """
     match = re.match("^(.*)\\[(.*)\\].*$", metadata.title)
     if match is not None:
         freeText = match.group(1) or ""

--- a/plugins/ntrrp/src/models/__init__.py
+++ b/plugins/ntrrp/src/models/__init__.py
@@ -9,3 +9,17 @@ from .segmentation_metadata import SegmentationMetadata
 from .working_layer import WorkingLayer
 from .workspace_metadata import WorkspaceMetadata
 from .workspace_layer import WorkspaceLayer
+
+__all__ = [
+    "CurrentMappingLayer",
+    "Item",
+    "Layer",
+    "Mapping",
+    "Project",
+    "Region",
+    "SegmentationLayer",
+    "SegmentationMetadata",
+    "WorkingLayer",
+    "WorkspaceMetadata",
+    "WorkspaceLayer",
+]

--- a/plugins/ntrrp/src/models/segmentation_metadata.py
+++ b/plugins/ntrrp/src/models/segmentation_metadata.py
@@ -23,4 +23,7 @@ class SegmentationMetadata:
         # the sixth segment will be eg 'T100'
         self.threshold = int(segments[5][1:])
 
-        self.differenceGroup = f"{self.difference} Differences ({self.endDate.strftime('%b %d')}–{self.startDate.strftime('%b %d')})"
+        self.differenceGroup = (
+            f"{self.difference} Differences "
+            f"({self.endDate.strftime('%b %d')}–{self.startDate.strftime('%b %d')})"
+        )

--- a/plugins/ntrrp/src/models/working_layer.py
+++ b/plugins/ntrrp/src/models/working_layer.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from pathlib import Path
 
 from qgis.core import (
@@ -27,8 +25,9 @@ class WorkingLayer(QgsVectorLayer, Layer):
 
         ensureDirectory(shapefilePath.parent)
 
-        # template SegmentationLayer sets initial attributes
-        writer = QgsVectorFileWriter(
+        # template SegmentationLayer sets initial attributes; constructing the
+        # writer writes the empty shapefile at shapefilePath as a side effect
+        QgsVectorFileWriter(
             shapefilePath.as_posix(),
             "utf-8",
             templateLayer.fields(),
@@ -52,7 +51,7 @@ class WorkingLayer(QgsVectorLayer, Layer):
 
         # Init vector layer
         QgsVectorLayer.__init__(
-            self, self.shapefilePath.as_posix(), f"Working Layer", "ogr"
+            self, self.shapefilePath.as_posix(), "Working Layer", "ogr"
         )
 
     def saveFeatures(self):
@@ -71,7 +70,7 @@ class WorkingLayer(QgsVectorLayer, Layer):
         else:
             error = (
                 f"An error occurred adding the layer {self.itemName} to the map.\n"
-                f"Check your QGIS logs for details."
+                "Check your QGIS logs for details."
             )
             guiError(error)
 
@@ -87,7 +86,7 @@ class WorkingLayer(QgsVectorLayer, Layer):
     @property
     def itemName(self):
         """Get an appropriate map layer name for this layer."""
-        return f"Working Layer"
+        return "Working Layer"
 
     @property
     def item(self) -> QgsLayerTreeLayer:

--- a/plugins/ntrrp/src/models/workspace_layer.py
+++ b/plugins/ntrrp/src/models/workspace_layer.py
@@ -18,7 +18,10 @@ class WorkspaceLayer(QgsRasterLayer, Layer):
         # weirdly true that URL-encoding of the layer ID does not work correctly
         encodedLayer = owsLayer.id.replace(" ", "%20")
         wmtsUrl = getNtrrpWmtsUrl()
-        wmtsParams = f"crs=EPSG:3577&format=image/png&layers={encodedLayer}&url={wmtsUrl}&styles&tileMatrixSet=EPSG:3577"
+        wmtsParams = (
+            f"crs=EPSG:3577&format=image/png&layers={encodedLayer}"
+            f"&url={wmtsUrl}&styles&tileMatrixSet=EPSG:3577"
+        )
 
         QgsRasterLayer.__init__(
             self, wmtsParams, parseContentMetadataDescription(owsLayer), "wms"

--- a/plugins/ntrrp/src/processing/__init__.py
+++ b/plugins/ntrrp/src/processing/__init__.py
@@ -6,3 +6,14 @@ from .full_burnt_areas_process import FullBurntAreasProcess
 from .rasterise_burnt_areas import RasteriseBurntAreas
 from .upload_burnt_areas import UploadBurntAreas
 from .validate_full_burnt_areas_process import ValidateFullBurntAreasProcess
+
+__all__ = [
+    "AttributeBurntAreas",
+    "DissolveBurntAreas",
+    "DownloadCurrentMapping",
+    "DownloadSegmentationData",
+    "FullBurntAreasProcess",
+    "RasteriseBurntAreas",
+    "UploadBurntAreas",
+    "ValidateFullBurntAreasProcess",
+]

--- a/plugins/ntrrp/src/processing/attribute_burnt_areas.py
+++ b/plugins/ntrrp/src/processing/attribute_burnt_areas.py
@@ -8,7 +8,10 @@ from qgis.core import (
     QgsProcessingParameterString,
     QgsProcessingParameterVectorLayer,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.utils import NTRRP_REGIONS
 
@@ -17,7 +20,8 @@ class AttributeBurntAreas(QgsProcessingAlgorithm):
     nextFsid = -1
 
     def initAlgorithm(self, config=None):
-        processing.ProcessingConfig.setSettingValue("IGNORE_INVALID_FEATURES", 1)
+        if processing is not None:
+            processing.ProcessingConfig.setSettingValue("IGNORE_INVALID_FEATURES", 1)
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 "DissolvedBurntAreas",
@@ -102,7 +106,8 @@ class AttributeBurntAreas(QgsProcessingAlgorithm):
         nextFsid = parameters["NextFsid"]
 
         feedback.pushInfo(
-            "Adding FSID, Mapping Period, Month, Region, Upload Date, Curent, and Comments attributes to your burnt areas …"
+            "Adding FSID, Mapping Period, Month, Region, Upload Date, Curent, and Comments "
+            "attributes to your burnt areas …"
         )
 
         # add FSID
@@ -188,7 +193,7 @@ class AttributeBurntAreas(QgsProcessingAlgorithm):
             "FIELD_NAME": "up_date",
             "FIELD_PRECISION": 0,
             "FIELD_TYPE": 2,
-            "FORMULA": f"value = today",
+            "FORMULA": "value = today",
             "GLOBAL": 'from datetime import date\n\ntoday = date.today().strftime(r"%Y-%m-%d")',
             "INPUT": outputs["AddRegion"]["OUTPUT"],
             "OUTPUT": QgsProcessing.TEMPORARY_OUTPUT,
@@ -207,7 +212,7 @@ class AttributeBurntAreas(QgsProcessingAlgorithm):
             "FIELD_NAME": "current",
             "FIELD_PRECISION": 0,
             "FIELD_TYPE": 2,
-            "FORMULA": f'value = "yes"',
+            "FORMULA": 'value = "yes"',
             "GLOBAL": "",
             "INPUT": outputs["AddUploadDate"]["OUTPUT"],
             "OUTPUT": QgsProcessing.TEMPORARY_OUTPUT,

--- a/plugins/ntrrp/src/processing/dissolve_burnt_areas.py
+++ b/plugins/ntrrp/src/processing/dissolve_burnt_areas.py
@@ -5,7 +5,10 @@ from qgis.core import (
     QgsProcessingParameterFeatureSink,
     QgsProcessingParameterVectorLayer,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 
 class DissolveBurntAreas(QgsProcessingAlgorithm):

--- a/plugins/ntrrp/src/processing/download_current_mapping.py
+++ b/plugins/ntrrp/src/processing/download_current_mapping.py
@@ -7,7 +7,10 @@ from qgis.core import (
     QgsProcessingMultiStepFeedback,
     QgsProcessingParameterEnum,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.utils import (
     ensureTempDirectories,

--- a/plugins/ntrrp/src/processing/download_segmentation_data.py
+++ b/plugins/ntrrp/src/processing/download_segmentation_data.py
@@ -10,7 +10,10 @@ from qgis.core import (
     QgsProcessingMultiStepFeedback,
     QgsProcessingParameterEnum,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.utils import (
     ensureDirectory,

--- a/plugins/ntrrp/src/processing/full_burnt_areas_process.py
+++ b/plugins/ntrrp/src/processing/full_burnt_areas_process.py
@@ -9,7 +9,10 @@ from qgis.core import (
     QgsProcessingParameterRasterLayer,
     QgsProcessingParameterVectorLayer,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.utils import NTRRP_REGIONS
 

--- a/plugins/ntrrp/src/processing/rasterise_burnt_areas.py
+++ b/plugins/ntrrp/src/processing/rasterise_burnt_areas.py
@@ -8,7 +8,10 @@ from qgis.core import (
     QgsProcessingParameterRasterLayer,
     QgsProcessingParameterVectorLayer,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from .color_table import addColorTable
 

--- a/plugins/ntrrp/src/processing/upload_burnt_areas.py
+++ b/plugins/ntrrp/src/processing/upload_burnt_areas.py
@@ -12,7 +12,10 @@ from qgis.core import (
     QgsProcessingParameterVectorLayer,
     QgsProject,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.utils import (
     ensureDirectory,
@@ -26,7 +29,8 @@ from ntrrp.src.utils import (
 
 class UploadBurntAreas(QgsProcessingAlgorithm):
     def initAlgorithm(self, config=None):
-        processing.ProcessingConfig.setSettingValue("IGNORE_INVALID_FEATURES", 1)
+        if processing is not None:
+            processing.ProcessingConfig.setSettingValue("IGNORE_INVALID_FEATURES", 1)
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 "AttributedBurntAreas",
@@ -59,7 +63,8 @@ class UploadBurntAreas(QgsProcessingAlgorithm):
         feedback = QgsProcessingMultiStepFeedback(1, model_feedback)
 
         feedback.pushInfo(
-            f"Rasterised Burnt Areas: {type(parameters['RasterisedBurntAreas'])} {str(parameters['RasterisedBurntAreas'])}"
+            f"Rasterised Burnt Areas: {type(parameters['RasterisedBurntAreas'])} "
+            f"{str(parameters['RasterisedBurntAreas'])}"
         )
 
         # Derive region string from enum parameter
@@ -118,7 +123,7 @@ class UploadBurntAreas(QgsProcessingAlgorithm):
         os.chdir(archiveDir)
         shutil.make_archive(archive, "zip", archiveDir)
 
-        feedback.pushInfo(f"Starting NAFI upload …")
+        feedback.pushInfo("Starting NAFI upload …")
 
         # try to upload the lot!
         try:
@@ -143,7 +148,7 @@ class UploadBurntAreas(QgsProcessingAlgorithm):
             feedback.pushInfo(f"Upload script command line: {commandLine}")
 
             # mojo from Patrice
-            returnCode = subprocess.run(args, shell=True)
+            subprocess.run(args, shell=True)
 
             # return code handling commented here because the UNIX 0=success convention is not respected
             # if returnCode == 0:
@@ -151,11 +156,12 @@ class UploadBurntAreas(QgsProcessingAlgorithm):
             # else:
             #   feedback.reportError("NAFI upload failed.", fatalError=True)
 
-        except Exception as err:
+        except Exception:
             raise RuntimeError(
-                r"""Exception occurred spawning external NAFI upload script …
-                                   check you can run scripts of the form
-                                   'python.exe upload.py -u https://test.firenorth.org.au/bfnt -f examples\bfnt_darwin_current_sr3577_tif.zip -cs 409600 -v'"""
+                "Exception occurred spawning external NAFI upload script … "
+                "check you can run scripts of the form 'python.exe upload.py "
+                "-u https://test.firenorth.org.au/bfnt "
+                r"-f examples\bfnt_darwin_current_sr3577_tif.zip -cs 409600 -v'"
             )
 
         # we need to return something to processing engine or it records a failure

--- a/plugins/ntrrp/src/processing/validate_full_burnt_areas_process.py
+++ b/plugins/ntrrp/src/processing/validate_full_burnt_areas_process.py
@@ -11,7 +11,10 @@ from qgis.core import (
     QgsProcessingParameterRasterLayer,
     QgsProcessingParameterVectorLayer,
 )
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.services import FsidService, FsidServiceError
 from ntrrp.src.utils import getNtrrpApiUrl, NTRRP_REGIONS

--- a/plugins/ntrrp/src/provider.py
+++ b/plugins/ntrrp/src/provider.py
@@ -1,7 +1,16 @@
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import QgsProcessingProvider
 
-from .processing import *
+from .processing import (
+    AttributeBurntAreas,
+    DissolveBurntAreas,
+    DownloadCurrentMapping,
+    DownloadSegmentationData,
+    FullBurntAreasProcess,
+    RasteriseBurntAreas,
+    UploadBurntAreas,
+    ValidateFullBurntAreasProcess,
+)
 
 
 class Provider(QgsProcessingProvider):

--- a/plugins/ntrrp/src/services/__init__.py
+++ b/plugins/ntrrp/src/services/__init__.py
@@ -4,3 +4,12 @@ from .fsid_service_error import FsidServiceError
 from .layer_service import LayerService
 from .mapping_service import MappingService
 from .workspace_service import WorkspaceMetadataService
+
+__all__ = [
+    "FsidRecord",
+    "FsidService",
+    "FsidServiceError",
+    "LayerService",
+    "MappingService",
+    "WorkspaceMetadataService",
+]

--- a/plugins/ntrrp/src/services/api_post.py
+++ b/plugins/ntrrp/src/services/api_post.py
@@ -1,7 +1,4 @@
-from typing import Optional, cast
-
 from qgis.PyQt.QtCore import QByteArray, QUrl, QJsonDocument
-from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkProxy
 
 from qgis.core import QgsSettings, QgsNetworkAccessManager

--- a/plugins/ntrrp/src/services/fsid_record.py
+++ b/plugins/ntrrp/src/services/fsid_record.py
@@ -8,7 +8,7 @@ class FsidRecord:
 
         if self.fsid is None:
             raise FsidServiceError(
-                f"No valid fire scar ID found in the retrieved JSON data", fsidJson
+                "No valid fire scar ID found in the retrieved JSON data", fsidJson
             )
 
         self.startDate = fsidJson.get("start_date", None)

--- a/plugins/ntrrp/src/services/fsid_service.py
+++ b/plugins/ntrrp/src/services/fsid_service.py
@@ -50,8 +50,8 @@ class FsidService(QObject):
                     raise Exception()
                 except BaseException:
                     raise FsidServiceError(
-                        f"Error parsing the retrieved NAFI FSID data!\n"
-                        f"Check the QGIS NAFI Burnt Areas Mapping message log for details.",
+                        "Error parsing the retrieved NAFI FSID data!\n"
+                        "Check the QGIS NAFI Burnt Areas Mapping message log for details.",
                         f"NAFI FSID data retrieved: {html.escape(responseContent)}",
                     )
             elif statusCode == 400:
@@ -59,9 +59,10 @@ class FsidService(QObject):
                 raise FsidServiceError(responseContent)
             else:
                 raise FsidServiceError(
-                    f"Error connecting to NAFI services!\n"
-                    f"Check the QGIS NAFI Burnt Areas Mapping message log for details.",
-                    f"Unexpected HTTP status code {statusCode} returned from server with response content {responseContent}",
+                    "Error connecting to NAFI services!\n"
+                    "Check the QGIS NAFI Burnt Areas Mapping message log for details.",
+                    f"Unexpected HTTP status code {statusCode} returned from server "
+                    f"with response content {responseContent}",
                 )
         except FsidServiceError:
             raise

--- a/plugins/ntrrp/src/services/mapping_service.py
+++ b/plugins/ntrrp/src/services/mapping_service.py
@@ -7,7 +7,10 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtWidgets import QAction
 from qgis.utils import iface
 
-import processing
+try:
+    import processing
+except ImportError:  # headless QGIS init without Processing plugin
+    processing = None  # type: ignore[assignment]
 
 from ntrrp.src.models import (
     CurrentMappingLayer,

--- a/plugins/ntrrp/src/test/test_upload.py
+++ b/plugins/ntrrp/src/test/test_upload.py
@@ -1,9 +1,4 @@
-import os.path as path
 import unittest
-
-from src.processing.dissolve_burnt_areas import DissolveBurntAreas
-from src.processing.attribute_burnt_areas import AttributeBurntAreas
-from src.processing.rasterise_burnt_areas import RasteriseBurntAreas
 
 
 class TestUpload(unittest.TestCase):

--- a/plugins/ntrrp/src/ui/__init__.py
+++ b/plugins/ntrrp/src/ui/__init__.py
@@ -1,1 +1,3 @@
 from .dock_widget import DockWidget
+
+__all__ = ["DockWidget"]

--- a/plugins/ntrrp/src/upload/upload.py
+++ b/plugins/ntrrp/src/upload/upload.py
@@ -161,7 +161,6 @@ def is_valid_url(url):
 
 def main(argv):
     script_name = os.path.basename(argv[0])
-    logname = os.path.splitext(script_name)[0]
 
     parser = argparse.ArgumentParser(prog=script_name, description=DESC)
     mainGroup = parser.add_argument_group(title="Main Parameters")
@@ -261,7 +260,7 @@ def main(argv):
         if client.upload_file(archive, debug):
             print("\n ===>  %s: upload successful..." % archive)
 
-    except ProcessingException as err:
+    except ProcessingException:
         raise RuntimeError("script terminated due to processing errors...")
 
     return

--- a/plugins/ntrrp/src/utils.py
+++ b/plugins/ntrrp/src/utils.py
@@ -14,7 +14,7 @@ NTRRP_REGIONS = ["Darwin", "Katherine"]
 
 NTRRP_WMS_URL = "https://test.firenorth.org.au/mapserver/bfnt/gwc/service/wms"
 NTRRP_WMTS_URL = "https://test.firenorth.org.au/mapserver/bfnt/gwc/service/wmts"
-NTRRP_DATA_URL = f"https://test.firenorth.org.au/bfnt/downloads"
+NTRRP_DATA_URL = "https://test.firenorth.org.au/bfnt/downloads"
 NTRRP_UPLOAD_URL = "https://test.firenorth.org.au/bfnt/upload.php"
 NTRRP_API_URL = "https://test.firenorth.org.au/bfnt/api"
 
@@ -163,21 +163,11 @@ def setDefaultProjectCrs(project):
 
 def connectionError(logMessage):
     """Raise a connection error."""
-    error = (
-        f"Error connecting to NAFI services!\n"
-        f"Check the QGIS NAFI Burnt Areas Mapping message log for details."
-    )
-    # guiError(error)
     qgsDebug(logMessage, Qgis.Critical)
 
 
 def capabilitiesError(errorString, capsXml):
     """Raise an error parsing the WMS capabilities file."""
-    error = (
-        f"Error parsing the retrieved NAFI WMS capabilities!\n"
-        f"Check the QGIS NAFI Burnt Areas Mapping message log for details."
-    )
-    # guiError(error)
     logMessage = f"NAFI WMS capabilities XML parse failure: {errorString}"
     qgsDebug(logMessage, Qgis.Critical)
     logMessage = f"NAFI WMS capabilities XML: {html.escape(capsXml)}"


### PR DESCRIPTION
- add `__all__` to model/processing/service/ui package `__init__` re-exports
- replace `from .processing import *` in provider with explicit imports
- remove unused imports across ntrrp/src modules
- drop unused local assignments (writer, returnCode, err, logname, error)
- drop redundant f-string prefixes on literal-only strings
- wrap over-length WMTS/request strings and long docstring summaries
- guard module-level `import processing` so ntrrp loads headless (verify-plugins.sh)
- skip `processing.ProcessingConfig.setSettingValue` in initAlgorithm when processing is unavailable
- ignore W503 in repo flake8 config (PEP 8-preferred break-before-operator)
- bump version to 1.2.1